### PR TITLE
Add combined lash recommendation helper

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -61,3 +61,18 @@ def get_mapping_recommendation(eye_shape):
         "notes": "Keine spezifische Empfehlung gefunden"
     })
 
+
+
+def get_combined_recommendation(left_shape, right_shape):
+    """Merge recommendations for two eye shapes."""
+    left_rec = get_mapping_recommendation(left_shape)
+    right_rec = get_mapping_recommendation(right_shape)
+    if left_shape == right_shape:
+        return left_rec
+    return {
+        "style": f"{left_rec['style']} / {right_rec['style']}",
+        "mapping": f"Left: {left_rec['mapping']}, Right: {right_rec['mapping']}",
+        "curl": f"{left_rec['curl']} / {right_rec['curl']}",
+        "length": f"Left: {left_rec['length']}, Right: {right_rec['length']}",
+        "notes": f"Left: {left_rec['notes']} | Right: {right_rec['notes']}",
+    }

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from rules import get_combined_recommendation, lash_mapping_rules
+
+
+def test_same_shapes_returns_single_recommendation():
+    rec = get_combined_recommendation('almond', 'almond')
+    assert rec == lash_mapping_rules['almond']
+
+
+def test_different_shapes_merged():
+    rec = get_combined_recommendation('almond', 'round')
+    assert rec['style'] == 'Beliebig / Cat / Squirrel'
+    assert rec['mapping'] == 'Left: Individuell, Right: Außen betont'
+    assert rec['curl'] == 'C / CC / C / D'


### PR DESCRIPTION
## Summary
- create `get_combined_recommendation` to merge lash mapping suggestions for both eyes
- add unit tests for the new helper

## Testing
- `pytest -q`

------
